### PR TITLE
make batch size for embeddings configurable for pinecode

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ pinecone:
   index: "..."
   api-key: "..."
   uri: "..."
-  
+  embedding-batch-size: 42
+
 chunking:
   strategy: "PARAGRAPH"
   limits:

--- a/src/main/java/io/github/fungrim/conf/PineconeConfig.java
+++ b/src/main/java/io/github/fungrim/conf/PineconeConfig.java
@@ -19,6 +19,9 @@ public interface PineconeConfig {
     @WithDefault("true")
     boolean enabled();
 
+    @WithDefault("96")
+    int embeddingBatchSize();
+
     public default boolean isLegal() {
         return !Strings.isNullOrEmpty(apiKey().orElse(null))
                 && !Strings.isNullOrEmpty(index().orElse(null))


### PR DESCRIPTION
The pinecode API have different batch size limits per model and will respond with a 400 if the call exceed max_batch_size for the model in use.

ref: https://docs.pinecone.io/reference/api/2025-10/inference/list_models
Smallest max_batch_size is the default value for the new config value 